### PR TITLE
Allow string ids on updateAttributes

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -243,6 +243,9 @@ MongoDB.prototype.count = function count(model, callback, where) {
 };
 
 MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, cb) {
+    if (typeof id === 'string') {
+        id = new ObjectID(id);
+    }
     this.collection(model).findAndModify({_id: id}, [['_id','asc']], {$set: data}, {}, function(err, object) {
         cb(err, object);
     });


### PR DESCRIPTION
Another tiny patch to allow string ids on updateAttributes.
