### PR TITLE
create object if wrong type of id is passed when using upsert

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -157,7 +157,7 @@ MongoDB.prototype.find = function find(model, id, callback) {
 
 MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, callback) {
     var adapter = this;
-    if (!data.id) return this.create(data, callback);
+    if (!data.id) return this.create(model, data, callback);
     this.find(model, data.id, function (err, inst) {
         if (err) return callback(err);
         if (inst) {

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -104,6 +104,15 @@ describe('mongodb', function(){
         done();
     });
 
+    it('should create an object if wrong id type is passed if using upsert', function(done) {
+        User.upsert({id: "1234"}, function(err, user) {
+            should.not.exist(err);
+            should.exist(user);
+
+            done();
+        });
+    });
+
     after(function(done){
         User.destroyAll(function(){
             Post.destroyAll(function() {


### PR DESCRIPTION
In case there is no id or wrong type of id (instead of `ObjectID`) is passed to `.upsert()`, we get an error in the console because the create method is not called with a `model` as parameter.
