### PR TITLE
Fix mongodb dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "mongodb": ">=0.9.9"
+    "mongodb": "1.x"
   },
   "devDependencies": {
     "jugglingdb": "https://github.com/1602/jugglingdb/archive/master.tar.gz",


### PR DESCRIPTION
The current build is broken since it is grabbing mongodb adapter v2.  This codebase will only work with 1.x.